### PR TITLE
Timer Updates

### DIFF
--- a/driver/clover_leaf.cpp
+++ b/driver/clover_leaf.cpp
@@ -187,6 +187,7 @@ global_variables initialise(parallel_ &parallel, const std::vector<std::string> 
 
   //	globals.step = 0;
   config.number_of_chunks = parallel.max_task;
+  config.warmup_steps = model.args.warmup_steps;
 
   auto globals = start(parallel, config, model.context);
   clover_barrier(globals);

--- a/driver/clover_leaf.cpp
+++ b/driver/clover_leaf.cpp
@@ -49,8 +49,10 @@
 
 // Output file handler
 std::ostream g_out(nullptr);
+std::ostream csv_out(nullptr);
 
 std::ofstream of;
+std::ofstream csv_file;
 
 global_variables initialise(parallel_ &parallel, const std::vector<std::string> &args) {
   global_config config;
@@ -97,7 +99,7 @@ global_variables initialise(parallel_ &parallel, const std::vector<std::string> 
     std::cout << "CloverLeaf:\n"
               << " - Ver.:     " << g_version << "\n"
               << " - Deck:     " << model.args.inFile << "\n"
-              << " - Out:      " << model.args.outFile << "\n"
+              << " - Out:      " << model.args.outFile << ", " << model.args.csv_file << "\n"
               << " - Profiler: " << (model.args.profile ? (*model.args.profile ? "true" : "false") : "deck-specified") << "\n"
               << "MPI:\n"
               << " - Enabled:     " << (mpi_enabled ? "true" : "false") << "\n"
@@ -123,6 +125,17 @@ global_variables initialise(parallel_ &parallel, const std::vector<std::string> 
     g_out.rdbuf(of.rdbuf());
   } else {
     g_out.rdbuf(std::cout.rdbuf());
+  }
+
+  config.using_csv = !model.args.csv_file.empty();
+  if (parallel.boss) {
+    if (config.using_csv) {
+      csv_file.open(model.args.csv_file);
+      if (!csv_file.is_open()) report_error((char *)"initialise", (char *)"Error opening specified CSV output file.");
+      csv_out.rdbuf(csv_file.rdbuf());
+    } else {
+      csv_out.rdbuf(std::cout.rdbuf());
+    }
   }
 
   if (parallel.boss) {

--- a/driver/definitions.h
+++ b/driver/definitions.h
@@ -109,7 +109,8 @@ struct grid_type {
 };
 
 struct profiler_type {
-
+  double host_to_device = 0.0;
+  double device_to_host = 0.0;
   double timestep = 0.0;
   double acceleration = 0.0;
   double PdV = 0.0;

--- a/driver/definitions.h
+++ b/driver/definitions.h
@@ -236,6 +236,7 @@ struct global_config {
   bool profiler_on;
   double end_time;
   int end_step;
+  int warmup_steps = 0;
 
   double dtinit;
   double dtmin;

--- a/driver/definitions.h
+++ b/driver/definitions.h
@@ -109,6 +109,7 @@ struct grid_type {
 };
 
 struct profiler_type {
+  double kernel_time = 0.0;
   double host_to_device = 0.0;
   double device_to_host = 0.0;
   double timestep = 0.0;

--- a/driver/definitions.h
+++ b/driver/definitions.h
@@ -237,6 +237,7 @@ struct global_config {
   double end_time;
   int end_step;
   int warmup_steps = 0;
+  bool using_csv;
 
   double dtinit;
   double dtmin;

--- a/driver/hydro.cpp
+++ b/driver/hydro.cpp
@@ -30,6 +30,7 @@
 #include "visit.h"
 
 extern std::ostream g_out;
+extern std::ostream csv_out;
 
 int maxloc(const std::vector<double> &totals, const int len) {
   int loc = -1;
@@ -216,6 +217,23 @@ void hydro(global_variables &globals, parallel_ &parallel) {
           };
           writeProfile(g_out);
           writeProfile(std::cout);
+
+          if (globals.config.using_csv) {
+            std::cout << "Saving timings to CSV\n" << std::endl;
+            csv_out << "timestep,ideal_gas,viscosity,PdV,revert,acceleration,"
+                    << "fluxes,cell_advection,mom_advection,reset,summary,"
+                    << "visits,tile_halo_exchange,self_halo_exchange,mpi_halo_exchange,"
+                    << "total_kernel,host_to_device,device_to_host,other" << std::endl
+                    << 1000 * p.timestep << "," << 1000 * p.ideal_gas << ","
+                    << 1000 * p.PdV << "," << 1000 * p.revert << ","
+                    << 1000 * p.acceleration << "," << 1000 * p.flux << ","
+                    << 1000 * p.cell_advection << "," << 1000 * p.mom_advection << ","
+                    << 1000 * p.reset << "," << 1000 * p.summary << "," << 1000 * p.visit << ","
+                    << 1000 * p.tile_halo_exchange << "," << 1000 * p.self_halo_exchange << ","
+                    << 1000 * p.mpi_halo_exchange << "," << 1000 * kernel_total << ","
+                    << 1000 * p.host_to_device << "," << 1000 * p.device_to_host << ","
+                    << 1000 * remainder << std::endl;
+          }
         }
       }
 

--- a/driver/initialise.h
+++ b/driver/initialise.h
@@ -35,6 +35,7 @@ struct run_args {
   std::string outFile;
   staging_buffer staging_buffer;
   std::optional<bool> profile;
+  int warmup_steps = 0;
 };
 
 struct model {
@@ -68,6 +69,7 @@ std::pair<T, run_args> list_and_parse(bool silent, const std::vector<T> &devices
         << "                                         Defaults to auto which elides the buffer if a device-aware (i.e CUDA-aware) is used.\n"
         << "                                         This option is no-op for CPU-only models.\n"
         << "                                         Setting this to false on an MPI that is not device-aware may cause a segfault.\n"
+        << "      --warmup,-w               <NUM>    Treat the first NUM iterations as warmup iterations and exclude them from all timing\n"
         << std::endl;
   };
 
@@ -146,6 +148,8 @@ std::pair<T, run_args> list_and_parse(bool silent, const std::vector<T> &devices
           std::exit(EXIT_FAILURE);
         }
       });
+    } else if (arg == "--warmup" || arg == "-w") {
+      readParam(i, "--warmup,-w specified but no number given", [&config](const auto &param) { config.warmup_steps = std::stoi(param); });
     } else {
       std::cerr << "Unknown argument: " << arg << std::endl;
       printHelp();

--- a/driver/initialise.h
+++ b/driver/initialise.h
@@ -36,6 +36,7 @@ struct run_args {
   staging_buffer staging_buffer;
   std::optional<bool> profile;
   int warmup_steps = 0;
+  std::string csv_file;
 };
 
 struct model {
@@ -70,6 +71,7 @@ std::pair<T, run_args> list_and_parse(bool silent, const std::vector<T> &devices
         << "                                         This option is no-op for CPU-only models.\n"
         << "                                         Setting this to false on an MPI that is not device-aware may cause a segfault.\n"
         << "      --warmup,-w               <NUM>    Treat the first NUM iterations as warmup iterations and exclude them from all timing\n"
+        << "      --csv,-c                 <FILE>    Path to a CSV file FILE in which to save timing information\n"
         << std::endl;
   };
 
@@ -150,6 +152,8 @@ std::pair<T, run_args> list_and_parse(bool silent, const std::vector<T> &devices
       });
     } else if (arg == "--warmup" || arg == "-w") {
       readParam(i, "--warmup,-w specified but no number given", [&config](const auto &param) { config.warmup_steps = std::stoi(param); });
+    } else if (arg == "--csv" || arg == "-c") {
+      readParam(i, "--csv,-c specified but no path was given", [&config](const auto &param) { config.csv_file = param; });
     } else {
       std::cerr << "Unknown argument: " << arg << std::endl;
       printHelp();

--- a/driver/timestep.cpp
+++ b/driver/timestep.cpp
@@ -68,7 +68,7 @@ void timestep(global_variables &globals, parallel_ &parallel) {
   fields[field_viscosity] = 1;
   update_halo(globals, fields, 1);
 
-  if (globals.profiler_on) kernel_time = timer();
+  if (globals.profiler_on) globals.profiler.kernel_time = timer();
 
   int jldt{}, kldt{};
   double dtlp{};
@@ -91,7 +91,9 @@ void timestep(global_variables &globals, parallel_ &parallel) {
 
   //	globals.queue.wait_and_throw();
   clover_min(globals.dt);
-  if (globals.profiler_on) globals.profiler.timestep += timer() - kernel_time;
+  if (globals.profiler_on) {
+    globals.profiler.timestep += timer() - globals.profiler.kernel_time;
+  }
 
   if (globals.dt < globals.config.dtmin) small = 1;
 

--- a/src/acc/build_field.cpp
+++ b/src/acc/build_field.cpp
@@ -23,6 +23,7 @@
 // size.
 
 #include "build_field.h"
+#include "../../driver/timer.h"
 
 // Allocate device buffers for the data arrays
 void build_field(global_variables &globals) {
@@ -66,6 +67,8 @@ void build_field(global_variables &globals) {
     double *xarea = field.xarea.data;
     double *yarea = field.yarea.data;
 
+    double kernel_time = timer();
+
 #pragma acc enter data create(density0[ : field.density0.N()]) create(density1[ : field.density1.N()])                    \
     create(energy0[ : field.energy0.N()]) create(energy1[ : field.energy1.N()]) create(pressure[ : field.pressure.N()])     \
     create(viscosity[ : field.viscosity.N()]) create(soundspeed[ : field.soundspeed.N()]) create(yvel0[ : field.yvel0.N()]) \
@@ -79,6 +82,10 @@ void build_field(global_variables &globals) {
     create(celly[ : field.celly.N()]) create(celldy[ : field.celldy.N()]) create(vertexx[ : field.vertexx.N()])             \
     create(vertexdx[ : field.vertexdx.N()]) create(vertexy[ : field.vertexy.N()]) create(vertexdy[ : field.vertexdy.N()])   \
     create(volume[ : field.volume.N()]) create(xarea[ : field.xarea.N()]) create(yarea[ : field.yarea.N()])
+
+    if (globals.profiler_on) {
+      globals.profiler.host_to_device += timer() - kernel_time;
+    }
 
     const int xrange = (t.info.t_xmax + 2) - (t.info.t_xmin - 2) + 1;
     const int yrange = (t.info.t_ymax + 2) - (t.info.t_ymin - 2) + 1;

--- a/src/acc/comms_kernel.cpp
+++ b/src/acc/comms_kernel.cpp
@@ -34,7 +34,6 @@
 #include "comms_kernel.h"
 #include "comms.h"
 #include "pack_kernel.h"
-#include "../../driver/timer.h"
 
 void clover_allocate_buffers(global_variables &globals, parallel_ &parallel) {
 
@@ -111,20 +110,10 @@ void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], co
 
   bool stage = globals.config.staging_buffer;
 
-  if (globals.profiler_on) {
-    globals.profiler.mpi_halo_exchange += timer() - globals.profiler.kernel_time;
-    globals.profiler.kernel_time = timer();
-  }
-
 #pragma acc enter data create(left_rcv[ : left_rcv_buffer.N()]) create(left_snd[ : left_snd_buffer.N()])                  \
     create(right_rcv[ : right_rcv_buffer.N()]) create(right_snd[ : right_snd_buffer.N()])                                        \
     create(top_rcv[ : top_rcv_buffer.N()]) create(top_snd[ : top_snd_buffer.N()])                                                \
     create(bottom_rcv[ : bottom_rcv_buffer.N()]) create(bottom_snd[ : bottom_snd_buffer.N()])
-
-  if (globals.profiler_on) {
-    globals.profiler.host_to_device += timer() - globals.profiler.kernel_time;
-    globals.profiler.kernel_time = timer();
-  }
 
   if (globals.chunk.chunk_neighbours[chunk_left] != external_face) {
     // do left exchanges

--- a/src/acc/comms_kernel.cpp
+++ b/src/acc/comms_kernel.cpp
@@ -34,6 +34,7 @@
 #include "comms_kernel.h"
 #include "comms.h"
 #include "pack_kernel.h"
+#include "../../driver/timer.h"
 
 void clover_allocate_buffers(global_variables &globals, parallel_ &parallel) {
 
@@ -110,10 +111,20 @@ void clover_exchange(global_variables &globals, const int fields[NUM_FIELDS], co
 
   bool stage = globals.config.staging_buffer;
 
+  if (globals.profiler_on) {
+    globals.profiler.mpi_halo_exchange += timer() - globals.profiler.kernel_time;
+    globals.profiler.kernel_time = timer();
+  }
+
 #pragma acc enter data create(left_rcv[ : left_rcv_buffer.N()]) create(left_snd[ : left_snd_buffer.N()])                  \
     create(right_rcv[ : right_rcv_buffer.N()]) create(right_snd[ : right_snd_buffer.N()])                                        \
     create(top_rcv[ : top_rcv_buffer.N()]) create(top_snd[ : top_snd_buffer.N()])                                                \
     create(bottom_rcv[ : bottom_rcv_buffer.N()]) create(bottom_snd[ : bottom_snd_buffer.N()])
+
+  if (globals.profiler_on) {
+    globals.profiler.host_to_device += timer() - globals.profiler.kernel_time;
+    globals.profiler.kernel_time = timer();
+  }
 
   if (globals.chunk.chunk_neighbours[chunk_left] != external_face) {
     // do left exchanges

--- a/src/acc/field_summary.cpp
+++ b/src/acc/field_summary.cpp
@@ -118,6 +118,19 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
       ke += cell_mass * 0.5 * vsqrd;
       press += cell_vol * pressure[j + (k)*base_stride];
     }
+    
+    if (globals.profiler_on) {
+      globals.profiler.summary += timer() - kernel_time;
+      kernel_time = timer();
+    }
+
+#pragma acc exit data copyout(vol, mass, ie, ke, press)
+
+    if (globals.profiler_on) {
+      globals.profiler.device_to_host += timer() - kernel_time;
+      kernel_time = timer();
+    }
+  }
 
 #if SYNC_BUFFERS
   globals.deviceToHost();

--- a/src/acc/field_summary.cpp
+++ b/src/acc/field_summary.cpp
@@ -118,19 +118,6 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
       ke += cell_mass * 0.5 * vsqrd;
       press += cell_vol * pressure[j + (k)*base_stride];
     }
-    
-    if (globals.profiler_on) {
-      globals.profiler.summary += timer() - kernel_time;
-      kernel_time = timer();
-    }
-
-#pragma acc exit data copyout(vol, mass, ie, ke, press)
-
-    if (globals.profiler_on) {
-      globals.profiler.device_to_host += timer() - kernel_time;
-      kernel_time = timer();
-    }
-  }
 
 #if SYNC_BUFFERS
   globals.deviceToHost();

--- a/src/acc/generate_chunk.cpp
+++ b/src/acc/generate_chunk.cpp
@@ -42,6 +42,8 @@ void generate_chunk(const int tile, global_variables &globals) {
   clover::Buffer1D<double> state_radius_buffer(globals.context, globals.config.number_of_states);
   clover::Buffer1D<int> state_geometry_buffer(globals.context, globals.config.number_of_states);
 
+  double start_time = timer();
+
   // Copy the data to the new views
   for (int state = 0; state < globals.config.number_of_states; ++state) {
     state_density_buffer[state] = globals.config.states[state].density;
@@ -55,6 +57,8 @@ void generate_chunk(const int tile, global_variables &globals) {
     state_radius_buffer[state] = globals.config.states[state].radius;
     state_geometry_buffer[state] = globals.config.states[state].geometry;
   }
+
+  globals.profiler.host_to_device += timer() - start_time;
 
   // Kokkos::deep_copy (TO, FROM)
 

--- a/src/acc/generate_chunk.cpp
+++ b/src/acc/generate_chunk.cpp
@@ -25,9 +25,13 @@
 //  @details Invoked the users specified chunk generator.
 
 #include "generate_chunk.h"
+#include "../../driver/timer.h"
 #include <cmath>
 
 void generate_chunk(const int tile, global_variables &globals) {
+  // We always want to time this, even though it's during startup, when most
+  // of the timers are turned off
+  double start_time = timer();
 
   // Need to copy the host array of state input data into a device array
   clover::Buffer1D<double> state_density_buffer(globals.context, globals.config.number_of_states);
@@ -54,6 +58,8 @@ void generate_chunk(const int tile, global_variables &globals) {
     state_radius_buffer[state] = globals.config.states[state].radius;
     state_geometry_buffer[state] = globals.config.states[state].geometry;
   }
+
+  globals.profiler.host_to_device += timer() - start_time;
 
   // Kokkos::deep_copy (TO, FROM)
 

--- a/src/acc/generate_chunk.cpp
+++ b/src/acc/generate_chunk.cpp
@@ -29,9 +29,6 @@
 #include <cmath>
 
 void generate_chunk(const int tile, global_variables &globals) {
-  // We always want to time this, even though it's during startup, when most
-  // of the timers are turned off
-  double start_time = timer();
 
   // Need to copy the host array of state input data into a device array
   clover::Buffer1D<double> state_density_buffer(globals.context, globals.config.number_of_states);
@@ -58,8 +55,6 @@ void generate_chunk(const int tile, global_variables &globals) {
     state_radius_buffer[state] = globals.config.states[state].radius;
     state_geometry_buffer[state] = globals.config.states[state].geometry;
   }
-
-  globals.profiler.host_to_device += timer() - start_time;
 
   // Kokkos::deep_copy (TO, FROM)
 
@@ -120,12 +115,25 @@ void generate_chunk(const int tile, global_variables &globals) {
     const double *state_radius = state_radius_buffer.data;
     const int *state_geometry = state_geometry_buffer.data;
 
-#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(globals.context.use_target)                                 \
+    // We always want to time this, even though it's during startup, when most
+    // of the timers are turned off
+    double start_time = timer();
+
+#pragma acc enter data clover_use_target(globals.context.use_target)                                 \
     copyin(state_density[ : state_density_buffer.N()]) copyin(state_energy[ : state_energy_buffer.N()])                                \
     copyin(state_xvel[ : state_xvel_buffer.N()]) copyin(state_yvel[ : state_yvel_buffer.N()])                                          \
     copyin(state_xmin[ : state_xmin_buffer.N()]) copyin(state_xmax[ : state_xmax_buffer.N()])                                          \
     copyin(state_ymin[ : state_ymin_buffer.N()]) copyin(state_ymax[ : state_ymax_buffer.N()])                                          \
     copyin(state_radius[ : state_radius_buffer.N()]) copyin(state_geometry[ : state_geometry_buffer.N()])                              \
+
+  globals.profiler.host_to_device += timer() - start_time;
+
+#pragma acc parallel loop gang worker vector collapse(2) clover_use_target(globals.context.use_target)                                 \
+    present(state_density[ : state_density_buffer.N()]) present(state_energy[ : state_energy_buffer.N()])                                \
+    present(state_xvel[ : state_xvel_buffer.N()]) present(state_yvel[ : state_yvel_buffer.N()])                                          \
+    present(state_xmin[ : state_xmin_buffer.N()]) present(state_xmax[ : state_xmax_buffer.N()])                                          \
+    present(state_ymin[ : state_ymin_buffer.N()]) present(state_ymax[ : state_ymax_buffer.N()])                                          \
+    present(state_radius[ : state_radius_buffer.N()]) present(state_geometry[ : state_geometry_buffer.N()])                              \
     present(energy0[ : field.energy0.N()], density0[ : field.density0.N()], xvel0[ : field.xvel0.N()], yvel0[: field.yvel0.N()],       \
             cellx[ : field.cellx.N()], celly[ : field.celly.N()], vertexx[ : field.vertexx.N()], vertexy[ : field.vertexy.N()])
     for (int j = 0; j < (yrange); j++) {

--- a/src/acc/update_halo.cpp
+++ b/src/acc/update_halo.cpp
@@ -819,13 +819,13 @@ void update_halo(global_variables &globals, int fields[NUM_FIELDS], int depth) {
   update_tile_halo(globals, fields, depth);
   if (globals.profiler_on) {
     globals.profiler.tile_halo_exchange += timer() - kernel_time;
-    kernel_time = timer();
+    globals.profiler.kernel_time = timer();
   }
 
   clover_exchange(globals, fields, depth);
 
   if (globals.profiler_on) {
-    globals.profiler.mpi_halo_exchange += timer() - kernel_time;
+    globals.profiler.mpi_halo_exchange += timer() - globals.profiler.kernel_time;
     kernel_time = timer();
   }
 

--- a/src/cuda/calc_dt.cpp
+++ b/src/cuda/calc_dt.cpp
@@ -19,6 +19,7 @@
 
 #include "calc_dt.h"
 #include "context.h"
+#include "../../driver/timer.h"
 #include <cmath>
 #include <numeric>
 #include <string>
@@ -92,7 +93,12 @@ void calc_dt_kernel(global_variables &globals, int x_min, int x_max, int y_min, 
     clover::reduce<double, BLOCK / 2>::run(mins, dt_min_val_buffer.data, [](auto l, auto r) { return std::fmin(l, r); });
   });
 
+  // JMK: Copies data back from device to host
+
+  //double start_time = timer();
   auto dt_min_val_host = dt_min_val_buffer.mirrored();
+  //globals.profiler.device_to_host += timer() - start_time;
+
   dt_min_val_buffer.release();
   dt_min_val = std::reduce(dt_min_val_host.begin(), dt_min_val_host.end(), g_big, [](auto l, auto r) { return std::fmin(l, r); });
 

--- a/src/cuda/calc_dt.cpp
+++ b/src/cuda/calc_dt.cpp
@@ -94,10 +94,17 @@ void calc_dt_kernel(global_variables &globals, int x_min, int x_max, int y_min, 
   });
 
   // JMK: Copies data back from device to host
+  if (globals.profiler_on) {
+    globals.profiler.timestep += timer() - globals.profiler.kernel_time;
+    globals.profiler.kernel_time = timer();
+  }
 
-  //double start_time = timer();
   auto dt_min_val_host = dt_min_val_buffer.mirrored();
-  //globals.profiler.device_to_host += timer() - start_time;
+
+  if (globals.profiler_on) {
+    globals.profiler.device_to_host += timer() - globals.profiler.kernel_time;
+    globals.profiler.kernel_time = timer();
+  }
 
   dt_min_val_buffer.release();
   dt_min_val = std::reduce(dt_min_val_host.begin(), dt_min_val_host.end(), g_big, [](auto l, auto r) { return std::fmin(l, r); });

--- a/src/cuda/field_summary.cpp
+++ b/src/cuda/field_summary.cpp
@@ -116,11 +116,15 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
       clover::reduce<double, BLOCK / 2>::run(ke, ke_buffer.data, [](auto l, auto r) { return l + r; });
       clover::reduce<double, BLOCK / 2>::run(press, press_buffer.data, [](auto l, auto r) { return l + r; });
     });
+    // JMK: Copies data back to host
+    double start_time = timer();
     auto vol_host = vol_buffer.mirrored();
     auto mass_host = mass_buffer.mirrored();
     auto ie_host = ie_buffer.mirrored();
     auto ke_host = ke_buffer.mirrored();
     auto press_host = press_buffer.mirrored();
+    double copy_time = timer() - start_time;
+
     vol = std::reduce(vol_host.begin(), vol_host.end(), vol, std::plus<>());
     mass = std::reduce(mass_host.begin(), mass_host.end(), mass, std::plus<>());
     ie = std::reduce(ie_host.begin(), ie_host.end(), ie, std::plus<>());

--- a/src/cuda/generate_chunk.cpp
+++ b/src/cuda/generate_chunk.cpp
@@ -30,10 +30,9 @@
 #include <cmath>
 
 void generate_chunk(const int tile, global_variables &globals) {
-  // JMK: intial host to device copy
-  double start_time;
- 
-  if (globals.profiler_on) start_time = timer();
+  // We always wan to time this, even though it's during startup, when most
+  // of the timers are turned off
+  double start_time = timer();
 
   // Need to copy the host array of state input data into a device array
   std::vector<double> state_density_vec(globals.config.number_of_states);
@@ -73,7 +72,7 @@ void generate_chunk(const int tile, global_variables &globals) {
   clover::Buffer1D<double> state_radius(globals.context, globals.config.number_of_states, state_radius_vec.data());
   clover::Buffer1D<int> state_geometry(globals.context, globals.config.number_of_states, state_geometry_vec.data());
   
-  if (globals.profiler_on) globals.profiler.host_to_device += timer() - start_time;
+  globals.profiler.host_to_device += timer() - start_time;
 
   const int x_min = globals.chunk.tiles[tile].info.t_xmin;
   const int x_max = globals.chunk.tiles[tile].info.t_xmax;

--- a/src/cuda/generate_chunk.cpp
+++ b/src/cuda/generate_chunk.cpp
@@ -26,9 +26,14 @@
 
 #include "generate_chunk.h"
 #include "context.h"
+#include "../../driver/timer.h"
 #include <cmath>
 
 void generate_chunk(const int tile, global_variables &globals) {
+  // JMK: intial host to device copy
+  double start_time;
+ 
+  if (globals.profiler_on) start_time = timer();
 
   // Need to copy the host array of state input data into a device array
   std::vector<double> state_density_vec(globals.config.number_of_states);
@@ -67,6 +72,8 @@ void generate_chunk(const int tile, global_variables &globals) {
   clover::Buffer1D<double> state_ymax(globals.context, globals.config.number_of_states, state_ymax_vec.data());
   clover::Buffer1D<double> state_radius(globals.context, globals.config.number_of_states, state_radius_vec.data());
   clover::Buffer1D<int> state_geometry(globals.context, globals.config.number_of_states, state_geometry_vec.data());
+  
+  if (globals.profiler_on) globals.profiler.host_to_device += timer() - start_time;
 
   const int x_min = globals.chunk.tiles[tile].info.t_xmin;
   const int x_max = globals.chunk.tiles[tile].info.t_xmax;

--- a/src/cuda/generate_chunk.cpp
+++ b/src/cuda/generate_chunk.cpp
@@ -30,7 +30,7 @@
 #include <cmath>
 
 void generate_chunk(const int tile, global_variables &globals) {
-  // We always wan to time this, even though it's during startup, when most
+  // We always want to time this, even though it's during startup, when most
   // of the timers are turned off
   double start_time = timer();
 

--- a/src/hip/calc_dt.cpp
+++ b/src/hip/calc_dt.cpp
@@ -20,6 +20,7 @@
 #include "calc_dt.h"
 #include "context.h"
 #include "hip/hip_runtime.h"
+#include "../../driver/timer.h"
 #include <cmath>
 #include <numeric>
 #include <string>
@@ -93,7 +94,19 @@ void calc_dt_kernel(global_variables &globals, int x_min, int x_max, int y_min, 
     clover::reduce<double, BLOCK / 2>::run(mins, dt_min_val_buffer.data, [](auto l, auto r) { return std::fmin(l, r); });
   });
 
+  // JMK: Copies data back from device to host
+  if (globals.profiler_on) {
+    globals.profiler.timestep += timer() - globals.profiler.kernel_time;
+    globals.profiler.kernel_time = timer();
+  }
+
   auto dt_min_val_host = dt_min_val_buffer.mirrored();
+
+  if (globals.profiler_on) {
+    globals.profiler.device_to_host += timer() - globals.profiler.kernel_time;
+    globals.profiler.kernel_time = timer();
+  }
+
   dt_min_val_buffer.release();
   dt_min_val = std::reduce(dt_min_val_host.begin(), dt_min_val_host.end(), g_big, [](auto l, auto r) { return std::fmin(l, r); });
 

--- a/src/hip/field_summary.cpp
+++ b/src/hip/field_summary.cpp
@@ -117,11 +117,23 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
       clover::reduce<double, BLOCK / 2>::run(ke, ke_buffer.data, [](auto l, auto r) { return l + r; });
       clover::reduce<double, BLOCK / 2>::run(press, press_buffer.data, [](auto l, auto r) { return l + r; });
     });
+
+    if (globals.profiler_on) {
+      globals.profiler.summary += timer() - kernel_time;
+      kernel_time = timer();
+    }
+
     auto vol_host = vol_buffer.mirrored();
     auto mass_host = mass_buffer.mirrored();
     auto ie_host = ie_buffer.mirrored();
     auto ke_host = ke_buffer.mirrored();
     auto press_host = press_buffer.mirrored();
+
+    if (globals.profiler_on) {
+      globals.profiler.device_to_host += timer() - kernel_time;
+      kernel_time = timer();
+    }
+
     vol = std::reduce(vol_host.begin(), vol_host.end(), vol, std::plus<>());
     mass = std::reduce(mass_host.begin(), mass_host.end(), mass, std::plus<>());
     ie = std::reduce(ie_host.begin(), ie_host.end(), ie, std::plus<>());

--- a/src/hip/generate_chunk.cpp
+++ b/src/hip/generate_chunk.cpp
@@ -26,9 +26,13 @@
 
 #include "generate_chunk.h"
 #include "context.h"
+#include "../../driver/timer.h"
 #include <cmath>
 
 void generate_chunk(const int tile, global_variables &globals) {
+  // We always want to time this, even though it's during startup, when most
+  // of the timers are turned off
+  double start_time = timer();
 
   // Need to copy the host array of state input data into a device array
   std::vector<double> state_density_vec(globals.config.number_of_states);
@@ -67,6 +71,8 @@ void generate_chunk(const int tile, global_variables &globals) {
   clover::Buffer1D<double> state_ymax(globals.context, globals.config.number_of_states, state_ymax_vec.data());
   clover::Buffer1D<double> state_radius(globals.context, globals.config.number_of_states, state_radius_vec.data());
   clover::Buffer1D<int> state_geometry(globals.context, globals.config.number_of_states, state_geometry_vec.data());
+
+  globals.profiler.host_to_device += timer() - start_time;
 
   const int x_min = globals.chunk.tiles[tile].info.t_xmin;
   const int x_max = globals.chunk.tiles[tile].info.t_xmax;

--- a/src/kokkos/generate_chunk.cpp
+++ b/src/kokkos/generate_chunk.cpp
@@ -25,8 +25,10 @@
 //  @details Invoked the users specified chunk generator.
 
 #include "generate_chunk.h"
+#include "../../driver/timer.h"
 
 void generate_chunk(const int tile, global_variables &globals) {
+  double start_time = timer();
 
   // Need to copy the host array of state input data into a device array
   // XXX This probably doesn't need ViewAllocateWithoutInitializing because of how small `globals.number_of_states` is.
@@ -77,6 +79,8 @@ void generate_chunk(const int tile, global_variables &globals) {
   Kokkos::deep_copy(state_ymax, hm_state_ymax);
   Kokkos::deep_copy(state_radius, hm_state_radius);
   Kokkos::deep_copy(state_geometry, hm_state_geometry);
+
+  globals.profiler.host_to_device += timer() - start_time;
 
   const int x_min = globals.chunk.tiles[tile].info.t_xmin;
   const int x_max = globals.chunk.tiles[tile].info.t_xmax;

--- a/src/kokkos/generate_chunk.cpp
+++ b/src/kokkos/generate_chunk.cpp
@@ -28,7 +28,6 @@
 #include "../../driver/timer.h"
 
 void generate_chunk(const int tile, global_variables &globals) {
-  double start_time = timer();
 
   // Need to copy the host array of state input data into a device array
   // XXX This probably doesn't need ViewAllocateWithoutInitializing because of how small `globals.number_of_states` is.
@@ -54,6 +53,8 @@ void generate_chunk(const int tile, global_variables &globals) {
   typename Kokkos::View<double *>::HostMirror hm_state_ymax = Kokkos::create_mirror_view(state_ymax);
   typename Kokkos::View<double *>::HostMirror hm_state_radius = Kokkos::create_mirror_view(state_radius);
   typename Kokkos::View<int *>::HostMirror hm_state_geometry = Kokkos::create_mirror_view(state_geometry);
+
+  double start_time = timer();
 
   // Copy the data to the new views
   for (int state = 0; state < globals.config.number_of_states; ++state) {

--- a/src/omp-target/calc_dt.cpp
+++ b/src/omp-target/calc_dt.cpp
@@ -105,6 +105,18 @@ void calc_dt_kernel(global_variables &globals, bool use_target, int x_min, int x
     }
   }
   
+  if (globals.profiler_on) {
+    globals.profiler.timestep += timer() - globals.profiler.kernel_time;
+    globals.profiler.kernel_time = timer();
+  }
+
+#pragma omp target exit data map(from : dt_min_val)
+  
+  if (globals.profiler_on) {
+    globals.profiler.device_to_host += timer() - globals.profiler.kernel_time;
+    globals.profiler.kernel_time = timer();
+  }
+  
   dt_min_val = dt_min_val0;
 
   dtl_control = static_cast<int>(10.01 * (jk_control - static_cast<int>(jk_control)));

--- a/src/omp-target/calc_dt.cpp
+++ b/src/omp-target/calc_dt.cpp
@@ -72,7 +72,7 @@ void calc_dt_kernel(global_variables &globals, bool use_target, int x_min, int x
 
   // XXX See https://forums.developer.nvidia.com/t/nvc-f-0000-internal-compiler-error-unhandled-size-for-preparing-max-constant/221740
   double dt_min_val0 = dt_min_val;
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target) map(tofrom : dt_min_val)                   \
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)                   \
     reduction(min : dt_min_val0)
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {

--- a/src/omp-target/calc_dt.cpp
+++ b/src/omp-target/calc_dt.cpp
@@ -72,7 +72,7 @@ void calc_dt_kernel(global_variables &globals, bool use_target, int x_min, int x
 
   // XXX See https://forums.developer.nvidia.com/t/nvc-f-0000-internal-compiler-error-unhandled-size-for-preparing-max-constant/221740
   double dt_min_val0 = dt_min_val;
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target) map(tofrom : dt_min_val)                   \
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target) map(to : dt_min_val)                   \
     reduction(min : dt_min_val0)
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {

--- a/src/omp-target/calc_dt.cpp
+++ b/src/omp-target/calc_dt.cpp
@@ -72,7 +72,7 @@ void calc_dt_kernel(global_variables &globals, bool use_target, int x_min, int x
 
   // XXX See https://forums.developer.nvidia.com/t/nvc-f-0000-internal-compiler-error-unhandled-size-for-preparing-max-constant/221740
   double dt_min_val0 = dt_min_val;
-#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target)                   \
+#pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(use_target) map(tofrom : dt_min_val)                   \
     reduction(min : dt_min_val0)
   for (int j = (y_min + 1); j < (y_max + 2); j++) {
     for (int i = (x_min + 1); i < (x_max + 2); i++) {

--- a/src/omp-target/calc_dt.cpp
+++ b/src/omp-target/calc_dt.cpp
@@ -105,18 +105,6 @@ void calc_dt_kernel(global_variables &globals, bool use_target, int x_min, int x
     }
   }
   
-  if (globals.profiler_on) {
-    globals.profiler.timestep += timer() - globals.profiler.kernel_time;
-    globals.profiler.kernel_time = timer();
-  }
-
-#pragma omp target exit data map(from : dt_min_val)
-  
-  if (globals.profiler_on) {
-    globals.profiler.device_to_host += timer() - globals.profiler.kernel_time;
-    globals.profiler.kernel_time = timer();
-  }
-  
   dt_min_val = dt_min_val0;
 
   dtl_control = static_cast<int>(10.01 * (jk_control - static_cast<int>(jk_control)));

--- a/src/omp-target/field_summary.cpp
+++ b/src/omp-target/field_summary.cpp
@@ -115,6 +115,7 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
       ke += cell_mass * 0.5 * vsqrd;
       press += cell_vol * pressure[j + (k)*base_stride];
     }
+  }
 
 #if SYNC_BUFFERS
   globals.deviceToHost();

--- a/src/omp-target/field_summary.cpp
+++ b/src/omp-target/field_summary.cpp
@@ -96,7 +96,8 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
       kernel_time = timer();
     }
 
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target) reduction(+ : vol, mass, ie, ke, press)
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target) map(to : vol) map(to : mass)   \
+    map(to : ie) map(to : ke) map(to : press) reduction(+ : vol, mass, ie, ke, press)
     for (int idx = 0; idx < ((ymax - ymin + 1) * (xmax - xmin + 1)); idx++) {
       const int j = xmin + 1 + idx % (xmax - xmin + 1);
       const int k = ymin + 1 + idx / (xmax - xmin + 1);

--- a/src/omp-target/field_summary.cpp
+++ b/src/omp-target/field_summary.cpp
@@ -96,8 +96,7 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
       kernel_time = timer();
     }
 
-#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target) map(to : vol) map(to : mass)   \
-    map(to : ie) map(to : ke) map(to : press) reduction(+ : vol, mass, ie, ke, press)
+#pragma omp target teams distribute parallel for simd clover_use_target(globals.context.use_target) reduction(+ : vol, mass, ie, ke, press)
     for (int idx = 0; idx < ((ymax - ymin + 1) * (xmax - xmin + 1)); idx++) {
       const int j = xmin + 1 + idx % (xmax - xmin + 1);
       const int k = ymin + 1 + idx / (xmax - xmin + 1);

--- a/src/omp-target/field_summary.cpp
+++ b/src/omp-target/field_summary.cpp
@@ -115,8 +115,21 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
       ke += cell_mass * 0.5 * vsqrd;
       press += cell_vol * pressure[j + (k)*base_stride];
     }
-  }
+    
+    if (globals.profiler_on) {
+      globals.profiler.summary += timer() - kernel_time;
+      kernel_time = timer();
+    }
 
+#pragma omp target exit data map(from : vol) map(from : mass)   \
+    map(from : ie) map(from : ke) map(from : press)
+  
+    if (globals.profiler_on) {
+      globals.profiler.device_to_host += timer() - kernel_time;
+      kernel_time = timer();
+    }
+  }
+  
 #if SYNC_BUFFERS
   globals.deviceToHost();
 #endif

--- a/src/omp-target/field_summary.cpp
+++ b/src/omp-target/field_summary.cpp
@@ -115,22 +115,6 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
       ke += cell_mass * 0.5 * vsqrd;
       press += cell_vol * pressure[j + (k)*base_stride];
     }
-    
-    if (globals.profiler_on) {
-      globals.profiler.summary += timer() - kernel_time;
-      kernel_time = timer();
-    }
-
-#pragma omp target exit data map(from : vol) map(from : mass)   \
-    map(from : ie) map(from : ke) map(from : press)
-  
-    if (globals.profiler_on) {
-      globals.profiler.device_to_host += timer() - kernel_time;
-      kernel_time = timer();
-    }
-  }
-  
-
 
 #if SYNC_BUFFERS
   globals.deviceToHost();

--- a/src/omp-target/generate_chunk.cpp
+++ b/src/omp-target/generate_chunk.cpp
@@ -29,6 +29,7 @@
 #include <cmath>
 
 void generate_chunk(const int tile, global_variables &globals) {
+  double kernel_time = timer();
 
   // Need to copy the host array of state input data into a device array
   clover::Buffer1D<double> state_density_buffer(globals.context, globals.config.number_of_states);
@@ -41,7 +42,7 @@ void generate_chunk(const int tile, global_variables &globals) {
   clover::Buffer1D<double> state_ymax_buffer(globals.context, globals.config.number_of_states);
   clover::Buffer1D<double> state_radius_buffer(globals.context, globals.config.number_of_states);
   clover::Buffer1D<int> state_geometry_buffer(globals.context, globals.config.number_of_states);
-
+    
   // Copy the data to the new views
   for (int state = 0; state < globals.config.number_of_states; ++state) {
     state_density_buffer[state] = globals.config.states[state].density;
@@ -55,6 +56,8 @@ void generate_chunk(const int tile, global_variables &globals) {
     state_radius_buffer[state] = globals.config.states[state].radius;
     state_geometry_buffer[state] = globals.config.states[state].geometry;
   }
+
+  globals.profiler.host_to_device += timer() - kernel_time;
 
   // Kokkos::deep_copy (TO, FROM)
 

--- a/src/omp-target/generate_chunk.cpp
+++ b/src/omp-target/generate_chunk.cpp
@@ -25,6 +25,7 @@
 //  @details Invoked the users specified chunk generator.
 
 #include "generate_chunk.h"
+#include "../../driver/timer.h"
 #include <cmath>
 
 void generate_chunk(const int tile, global_variables &globals) {
@@ -111,6 +112,17 @@ void generate_chunk(const int tile, global_variables &globals) {
     const double *state_ymax = state_ymax_buffer.data;
     const double *state_radius = state_radius_buffer.data;
     const int *state_geometry = state_geometry_buffer.data;
+
+    double kernel_time = timer();
+
+#pragma omp target enter data\
+    map(to : state_density[ : state_density_buffer.N()]) map(to : state_energy[ : state_energy_buffer.N()])                                \
+    map(to : state_xvel[ : state_xvel_buffer.N()]) map(to : state_yvel[ : state_yvel_buffer.N()])                                          \
+    map(to : state_xmin[ : state_xmin_buffer.N()]) map(to : state_xmax[ : state_xmax_buffer.N()])                                          \
+    map(to : state_ymin[ : state_ymin_buffer.N()]) map(to : state_ymax[ : state_ymax_buffer.N()])                                          \
+    map(to : state_radius[ : state_radius_buffer.N()]) map(to : state_geometry[ : state_geometry_buffer.N()])
+
+    globals.profiler.host_to_device += timer() - kernel_time;
 
 #pragma omp target teams distribute parallel for simd collapse(2) clover_use_target(globals.context.use_target)                            \
     map(to : state_density[ : state_density_buffer.N()]) map(to : state_energy[ : state_energy_buffer.N()])                                \

--- a/src/omp-target/generate_chunk.cpp
+++ b/src/omp-target/generate_chunk.cpp
@@ -29,7 +29,6 @@
 #include <cmath>
 
 void generate_chunk(const int tile, global_variables &globals) {
-  double kernel_time = timer();
 
   // Need to copy the host array of state input data into a device array
   clover::Buffer1D<double> state_density_buffer(globals.context, globals.config.number_of_states);
@@ -42,6 +41,8 @@ void generate_chunk(const int tile, global_variables &globals) {
   clover::Buffer1D<double> state_ymax_buffer(globals.context, globals.config.number_of_states);
   clover::Buffer1D<double> state_radius_buffer(globals.context, globals.config.number_of_states);
   clover::Buffer1D<int> state_geometry_buffer(globals.context, globals.config.number_of_states);
+
+  double kernel_time = timer();
     
   // Copy the data to the new views
   for (int state = 0; state < globals.config.number_of_states; ++state) {

--- a/src/raja/generate_chunk.cpp
+++ b/src/raja/generate_chunk.cpp
@@ -26,6 +26,7 @@
 
 #include "generate_chunk.h"
 #include "context.h"
+#include "timer.h"
 #include <cmath>
 
 #include <umpire/Allocator.hpp>
@@ -41,6 +42,8 @@ void generate_chunk(const int tile, global_variables &globals) {
   umpire::Allocator alloc = rm.getAllocator("HOST");
   umpire::TypedAllocator<double> int_vector_allocator(alloc);
   umpire::TypedAllocator<double> double_vector_allocator(alloc);
+  
+  double kernel_time = timer();
 
   std::vector<double, umpire::TypedAllocator<double>> state_density_vec(globals.config.number_of_states, double_vector_allocator);
   std::vector<double, umpire::TypedAllocator<double>> state_energy_vec(globals.config.number_of_states, double_vector_allocator);
@@ -78,6 +81,8 @@ void generate_chunk(const int tile, global_variables &globals) {
   clover::Buffer1D<double> state_ymax(globals.context, globals.config.number_of_states, state_ymax_vec.data());
   clover::Buffer1D<double> state_radius(globals.context, globals.config.number_of_states, state_radius_vec.data());
   clover::Buffer1D<int> state_geometry(globals.context, globals.config.number_of_states, state_geometry_vec.data());
+
+  globals.profiler.host_to_device += timer() - kernel_time;
 
   const int x_min = globals.chunk.tiles[tile].info.t_xmin;
   const int x_max = globals.chunk.tiles[tile].info.t_xmax;

--- a/src/sycl-usm/context.h
+++ b/src/sycl-usm/context.h
@@ -84,6 +84,7 @@ template <typename T> struct Buffer2D {
   std::vector<T> mirrored() const {
     std::vector<T> buffer(sizeX * sizeY);
     queue->memcpy(buffer.data(), data, sizeof(T) * sizeX * sizeY);
+    queue->wait();
     return buffer;
   }
   clover::BufferMirror2D<T> mirrored2() { return {mirrored(), extent<0>(), extent<1>()}; }

--- a/src/sycl-usm/generate_chunk.cpp
+++ b/src/sycl-usm/generate_chunk.cpp
@@ -26,8 +26,10 @@
 
 #include "generate_chunk.h"
 #include "context.h"
+#include "timer.h"
 
 void generate_chunk(const int tile, global_variables &globals) {
+  double kernel_time = timer();
 
   // Need to copy the host array of state input data into a device array
 #ifdef CLOVERLEAF_MANAGED_ALLOC
@@ -103,8 +105,10 @@ void generate_chunk(const int tile, global_variables &globals) {
   globals.context.queue.memcpy(state_radius.data, state_radius_vec.data(), sizeof(double) * globals.config.number_of_states);
   globals.context.queue.memcpy(state_geometry.data, state_geometry_vec.data(), sizeof(int) * globals.config.number_of_states);
 
-  globals.config.queue.wait();
+  globals.context.queue.wait();
 #endif
+
+  globals.profiler.host_to_device = timer() - kernel_time;
 
   // Kokkos::deep_copy (TO, FROM)
 

--- a/src/sycl-usm/generate_chunk.cpp
+++ b/src/sycl-usm/generate_chunk.cpp
@@ -29,10 +29,12 @@
 #include "timer.h"
 
 void generate_chunk(const int tile, global_variables &globals) {
-  double kernel_time = timer();
+  double kernel_time;
 
   // Need to copy the host array of state input data into a device array
 #ifdef CLOVERLEAF_MANAGED_ALLOC
+  kernel_time = timer();
+
   clover::Buffer1D<double> state_density(globals.context, globals.config.number_of_states);
   clover::Buffer1D<double> state_energy(globals.context, globals.config.number_of_states);
   clover::Buffer1D<double> state_xvel(globals.context, globals.config.number_of_states);
@@ -57,6 +59,9 @@ void generate_chunk(const int tile, global_variables &globals) {
     state_radius[state] = globals.config.states[state].radius;
     state_geometry[state] = globals.config.states[state].geometry;
   }
+
+  globals.profiler.host_to_device = timer() - kernel_time;
+
 #else
   std::vector<double> state_density_vec(globals.config.number_of_states);
   std::vector<double> state_energy_vec(globals.config.number_of_states);
@@ -68,6 +73,8 @@ void generate_chunk(const int tile, global_variables &globals) {
   std::vector<double> state_ymax_vec(globals.config.number_of_states);
   std::vector<double> state_radius_vec(globals.config.number_of_states);
   std::vector<int> state_geometry_vec(globals.config.number_of_states);
+
+  kernel_time = timer();
 
   // Copy the data to the new views
   for (int state = 0; state < globals.config.number_of_states; ++state) {
@@ -83,6 +90,8 @@ void generate_chunk(const int tile, global_variables &globals) {
     state_geometry_vec[state] = globals.config.states[state].geometry;
   }
 
+  globals.profiler.host_to_device = timer() - kernel_time;
+
   clover::Buffer1D<double> state_density(globals.context, globals.config.number_of_states);
   clover::Buffer1D<double> state_energy(globals.context, globals.config.number_of_states);
   clover::Buffer1D<double> state_xvel(globals.context, globals.config.number_of_states);
@@ -93,6 +102,8 @@ void generate_chunk(const int tile, global_variables &globals) {
   clover::Buffer1D<double> state_ymax(globals.context, globals.config.number_of_states);
   clover::Buffer1D<double> state_radius(globals.context, globals.config.number_of_states);
   clover::Buffer1D<int> state_geometry(globals.context, globals.config.number_of_states);
+
+  kernel_time = timer();
 
   globals.context.queue.memcpy(state_density.data, state_density_vec.data(), sizeof(double) * globals.config.number_of_states);
   globals.context.queue.memcpy(state_energy.data, state_energy_vec.data(), sizeof(double) * globals.config.number_of_states);
@@ -106,9 +117,10 @@ void generate_chunk(const int tile, global_variables &globals) {
   globals.context.queue.memcpy(state_geometry.data, state_geometry_vec.data(), sizeof(int) * globals.config.number_of_states);
 
   globals.context.queue.wait();
+  
+  globals.profiler.host_to_device = timer() - kernel_time;
 #endif
 
-  globals.profiler.host_to_device = timer() - kernel_time;
 
   // Kokkos::deep_copy (TO, FROM)
 


### PR DESCRIPTION
- Separates out data movement for OpenACC, RAJA, Kokkos, CUDA, HIP, SYCL USM, and OpenMP Target version of the code
- Added timers for this isolated data movement and omitted this time from existing timers
- Added command line option (`--warmup` or `-w`) to specify the number of warmup iterations to omit from timing