### PR TITLE
Rename sync function to clover_sync

### DIFF
--- a/driver/advection.cpp
+++ b/driver/advection.cpp
@@ -53,7 +53,7 @@ void advection(global_variables &globals) {
   }
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.cell_advection += timer() - kernel_time;
   }
 
@@ -75,7 +75,7 @@ void advection(global_variables &globals) {
   }
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.mom_advection += timer() - kernel_time;
   }
 
@@ -90,7 +90,7 @@ void advection(global_variables &globals) {
   }
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.cell_advection += timer() - kernel_time;
   }
 
@@ -112,7 +112,7 @@ void advection(global_variables &globals) {
   }
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.mom_advection += timer() - kernel_time;
   }
 }

--- a/driver/sync.h
+++ b/driver/sync.h
@@ -21,5 +21,5 @@
 
 #include "definitions.h"
 
-void sync();
+void clover_sync();
 

--- a/driver/timestep.cpp
+++ b/driver/timestep.cpp
@@ -50,7 +50,7 @@ void timestep(global_variables &globals, parallel_ &parallel) {
   }
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.ideal_gas += timer() - kernel_time;
   }
 
@@ -68,7 +68,7 @@ void timestep(global_variables &globals, parallel_ &parallel) {
   viscosity(globals);
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.viscosity += timer() - kernel_time;
   }
 
@@ -102,7 +102,7 @@ void timestep(global_variables &globals, parallel_ &parallel) {
   clover_min(globals.dt);
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.timestep += timer() - globals.profiler.kernel_time;
   }
 

--- a/driver/visit.cpp
+++ b/driver/visit.cpp
@@ -61,7 +61,7 @@ void visit(global_variables &globals, parallel_ &parallel) {
     ideal_gas(globals, tile, false);
   }
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.ideal_gas += timer() - kernel_time;
   }
 

--- a/src/acc/sync.cpp
+++ b/src/acc/sync.cpp
@@ -19,5 +19,5 @@
 
 #include "sync.h"
 
-void sync() {}
+void clover_sync() {}
 

--- a/src/cuda/sync.cpp
+++ b/src/cuda/sync.cpp
@@ -19,5 +19,5 @@
 
 #include "sync.h"
 
-void sync() {}
+void clover_sync() {}
 

--- a/src/hip/sync.cpp
+++ b/src/hip/sync.cpp
@@ -19,5 +19,5 @@
 
 #include "sync.h"
 
-void sync() {}
+void clover_sync() {}
 

--- a/src/kokkos/PdV.cpp
+++ b/src/kokkos/PdV.cpp
@@ -100,7 +100,7 @@ void PdV(global_variables &globals, bool predict) {
 
   clover_check_error(globals.error_condition);
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.PdV += timer() - kernel_time;
   }
 
@@ -115,7 +115,7 @@ void PdV(global_variables &globals, bool predict) {
     }
 
     if (globals.profiler_on) {
-      if (globals.should_sync_profile) sync();
+      if (globals.should_sync_profile) clover_sync();
       globals.profiler.ideal_gas += timer() - kernel_time;
     }
 
@@ -130,7 +130,7 @@ void PdV(global_variables &globals, bool predict) {
     if (globals.profiler_on) kernel_time = timer();
     revert(globals);
     if (globals.profiler_on) {
-      if (globals.should_sync_profile) sync();
+      if (globals.should_sync_profile) clover_sync();
       globals.profiler.revert += timer() - kernel_time;
     }
   }

--- a/src/kokkos/accelerate.cpp
+++ b/src/kokkos/accelerate.cpp
@@ -72,7 +72,7 @@ void accelerate(global_variables &globals) {
   }
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.acceleration += timer() - kernel_time;
   }
 }

--- a/src/kokkos/field_summary.cpp
+++ b/src/kokkos/field_summary.cpp
@@ -139,7 +139,7 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
   }
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.ideal_gas += timer() - kernel_time;
     kernel_time = timer();
   }
@@ -179,7 +179,7 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
   clover_sum(press);
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.summary += timer() - kernel_time;
   }
 

--- a/src/kokkos/flux_calc.cpp
+++ b/src/kokkos/flux_calc.cpp
@@ -60,7 +60,7 @@ void flux_calc(global_variables &globals) {
   }
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.flux += timer() - kernel_time;
   }
 }

--- a/src/kokkos/reset_field.cpp
+++ b/src/kokkos/reset_field.cpp
@@ -64,7 +64,7 @@ void reset_field(global_variables &globals) {
   }
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.reset += timer() - kernel_time;
   }
 }

--- a/src/kokkos/sync.cpp
+++ b/src/kokkos/sync.cpp
@@ -20,7 +20,7 @@
 #include "sync.h"
 #include <Kokkos_Core.hpp>
 
-void sync() {
+void clover_sync() {
   Kokkos::fence();
 }
 

--- a/src/kokkos/update_halo.cpp
+++ b/src/kokkos/update_halo.cpp
@@ -638,7 +638,7 @@ void update_halo(global_variables &globals, int fields[NUM_FIELDS], const int de
   if (globals.profiler_on) kernel_time = timer();
   update_tile_halo(globals, fields, depth);
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.tile_halo_exchange += timer() - kernel_time;
     kernel_time = timer();
   }
@@ -676,7 +676,7 @@ void update_halo(global_variables &globals, int fields[NUM_FIELDS], const int de
   }
 
   if (globals.profiler_on) {
-    if (globals.should_sync_profile) sync();
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.self_halo_exchange += timer() - kernel_time;
   }
 }

--- a/src/omp-target/sync.cpp
+++ b/src/omp-target/sync.cpp
@@ -19,5 +19,5 @@
 
 #include "sync.h"
 
-void sync() {}
+void clover_sync() {}
 

--- a/src/omp/sync.cpp
+++ b/src/omp/sync.cpp
@@ -19,5 +19,5 @@
 
 #include "sync.h"
 
-void sync() {}
+void clover_sync() {}
 

--- a/src/raja/sync.cpp
+++ b/src/raja/sync.cpp
@@ -19,5 +19,5 @@
 
 #include "sync.h"
 
-void sync() {}
+void clover_sync() {}
 

--- a/src/serial/sync.cpp
+++ b/src/serial/sync.cpp
@@ -19,5 +19,5 @@
 
 #include "sync.h"
 
-void sync() {}
+void clover_sync() {}
 

--- a/src/std-indices/sync.cpp
+++ b/src/std-indices/sync.cpp
@@ -19,5 +19,5 @@
 
 #include "sync.h"
 
-void sync() {}
+void clover_sync() {}
 

--- a/src/sycl-acc/sync.cpp
+++ b/src/sycl-acc/sync.cpp
@@ -19,5 +19,5 @@
 
 #include "sync.h"
 
-void sync() {}
+void clover_sync() {}
 

--- a/src/sycl-usm/sync.cpp
+++ b/src/sycl-usm/sync.cpp
@@ -19,5 +19,5 @@
 
 #include "sync.h"
 
-void sync() {}
+void clover_sync() {}
 


### PR DESCRIPTION
AdaptiveCpp complains otherwise. Probably a namespace conflict with something in a library.
```
>> 157    /global/u1/j/jhdavis/CloverLeaf/src/sycl-usm/sync.cpp:22:6: error: 'sync' is missing exception specification 'throw()'
158       22 | void sync() {}
159          |      ^
160          |             throw()
161    /global/u1/j/jhdavis/CloverLeaf/driver/sync.h:24:6: note: previous declaration is here
162       24 | void sync();
163          |      ^
```