### PR TITLE
Added implmentations for clover_sync for CUDA and HIP

### DIFF
--- a/src/cuda/calc_dt.cpp
+++ b/src/cuda/calc_dt.cpp
@@ -19,6 +19,7 @@
 
 #include "calc_dt.h"
 #include "context.h"
+#include "sync.h"
 #include "../../driver/timer.h"
 #include <cmath>
 #include <numeric>

--- a/src/cuda/calc_dt.cpp
+++ b/src/cuda/calc_dt.cpp
@@ -95,6 +95,7 @@ void calc_dt_kernel(global_variables &globals, int x_min, int x_max, int y_min, 
 
   // JMK: Copies data back from device to host
   if (globals.profiler_on) {
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.timestep += timer() - globals.profiler.kernel_time;
     globals.profiler.kernel_time = timer();
   }

--- a/src/cuda/field_summary.cpp
+++ b/src/cuda/field_summary.cpp
@@ -118,6 +118,7 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
     });
 
     if (globals.profiler_on) {
+      if (globals.should_sync_profile) clover_sync();
       globals.profiler.summary += timer() - kernel_time;
       kernel_time = timer();
     }

--- a/src/cuda/field_summary.cpp
+++ b/src/cuda/field_summary.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "field_summary.h"
+#include "sync.h"
 #include "context.h"
 #include "ideal_gas.h"
 #include "report.h"

--- a/src/cuda/sync.cpp
+++ b/src/cuda/sync.cpp
@@ -19,5 +19,6 @@
 
 #include "sync.h"
 
-void clover_sync() {}
-
+void clover_sync() {
+    clover::checkError(cudaDeviceSynchronize());
+}

--- a/src/hip/calc_dt.cpp
+++ b/src/hip/calc_dt.cpp
@@ -19,6 +19,7 @@
 
 #include "calc_dt.h"
 #include "context.h"
+#include "sync.h"
 #include "hip/hip_runtime.h"
 #include "../../driver/timer.h"
 #include <cmath>

--- a/src/hip/calc_dt.cpp
+++ b/src/hip/calc_dt.cpp
@@ -96,6 +96,7 @@ void calc_dt_kernel(global_variables &globals, int x_min, int x_max, int y_min, 
 
   // JMK: Copies data back from device to host
   if (globals.profiler_on) {
+    if (globals.should_sync_profile) clover_sync();
     globals.profiler.timestep += timer() - globals.profiler.kernel_time;
     globals.profiler.kernel_time = timer();
   }

--- a/src/hip/field_summary.cpp
+++ b/src/hip/field_summary.cpp
@@ -119,6 +119,7 @@ void field_summary(global_variables &globals, parallel_ &parallel) {
     });
 
     if (globals.profiler_on) {
+      if (globals.should_sync_profile) clover_sync();
       globals.profiler.summary += timer() - kernel_time;
       kernel_time = timer();
     }

--- a/src/hip/field_summary.cpp
+++ b/src/hip/field_summary.cpp
@@ -19,6 +19,7 @@
 
 #include "field_summary.h"
 #include "context.h"
+#include "sync.h"
 #include "hip/hip_runtime.h"
 #include "ideal_gas.h"
 #include "report.h"

--- a/src/hip/sync.cpp
+++ b/src/hip/sync.cpp
@@ -19,5 +19,6 @@
 
 #include "sync.h"
 
-void clover_sync() {}
-
+void clover_sync() {
+    clover::checkError(hipDeviceSynchronize());
+}


### PR DESCRIPTION
- Fixes issue where manual timers reported incorrect kernel times due to asynchronous calls where were only waited for in later kernels (mostly the halo exchange) by adding implementations of `clover_sync` for CUDA and HIP
- For CUDA on Perlmutter this takes us from ~64.7s runs to ~64.8s runs, so overhead is minimal